### PR TITLE
cicd: build workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,55 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build wheel on cp${{ matrix.python }}-${{ matrix.os}}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # manylinux builds
+          - os: ubuntu-latest
+            python: "36"
+            platform: manylinux_x86_64
+          - os: ubuntu-latest
+            python: "37"
+            platform: manylinux_x86_64
+          - os: ubuntu-latest
+            python: "38"
+            platform: manylinux_x86_64
+          
+          # macos builds
+          - os: macos-latest
+            python: "36"
+            platform: macosx_x86_64
+          - os: macos-latest
+            python: "37"
+            platform: macosx_x86_64
+          - os: macos-latest
+            python: "38"
+            platform: macosx_x86_64
+
+          # windows builds
+          - os: windows-latest
+            python: "36"
+            platform: win_amd64
+          - os: windows-latest
+            python: "37"
+            platform: win_amd64
+          - os: windows-latest
+            python: "38"
+            platform: win_amd64
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.1.3
+        env:
+          CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform }}
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_BUILD_VERBOSITY: 3
+          CIBW_TEST_COMMAND: python -c "import cython_bbox"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,3 @@
 [build-system]
-requires = ["setuptools>=58.0.4", "wheel", "Cython>=0.29.24"]
+requires = ["Cython>=0.29.24", "numpy>=1.0.0", "setuptools>=58.0.4", "wheel"]
 build-backend = "setuptools.build_meta"
-
-[project]
-dependencies = [
-    "numpy >= 1.0.0"
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,3 @@
 [build-system]
 requires = ["Cython>=0.29.24", "numpy>=1.0.0", "setuptools>=58.0.4", "wheel"]
 build-backend = "setuptools.build_meta"
-
-[project]
-dependencies = ["numpy>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [build-system]
 requires = ["Cython>=0.29.24", "numpy>=1.0.0", "setuptools>=58.0.4", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[project]
+dependencies = ["numpy>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = ["setuptools>=58.0.4", "wheel", "Cython>=0.29.24"]
+build-backend = "setuptools.build_meta"
+
+[project]
+dependencies = [
+    "numpy >= 1.0.0"
+]

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ ext_modules = cythonize(ext_modules, compiler_directives=compiler_directives)
 
 setup(
     name="cython_bbox",
-    ext_modules=ext_modules,
     version="0.1.3",
     description="Standalone cython_bbox",
     long_description=long_description,
@@ -48,4 +47,6 @@ setup(
     author_email="samson.c.wang@gmail.com",
     url="https://github.com/samson-wang/cython_bbox.git",
     keywords=["cython_bbox"],
+    ext_modules=ext_modules,
+    install_requires=["numpy>=1.0.0"],
 )

--- a/setup.py
+++ b/setup.py
@@ -7,42 +7,45 @@
 
 from __future__ import print_function
 
-from Cython.Build import cythonize
-from Cython.Distutils import build_ext
-from setuptools import Extension
-from setuptools import setup
+import sys
 
 import numpy as np
+from Cython.Build import cythonize
+from setuptools import Extension, setup
 
-
-# Obtain the numpy include directory.  This logic works across numpy versions.
-try:
-    numpy_include = np.get_include()
-except AttributeError:
-    numpy_include = np.get_numpy_include()
+# Obtain the numpy include directory, only for numpy >= 1.0.0
+numpy_include = np.get_include()
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+
+if sys.platform == "win32":
+    extra_compile_args = ["/Qstd=c99"]
+else:
+    extra_compile_args = ["-std=c99"]
+
 ext_modules = [
     Extension(
-        name='cython_bbox',
-        sources=['src/cython_bbox.pyx'],
-        extra_compile_args = {'gcc': ['/Qstd=c99']},
-        include_dirs=[numpy_include]
+        name="cython_bbox",
+        sources=["src/cython_bbox.pyx"],
+        extra_compile_args=extra_compile_args,
+        include_dirs=[numpy_include],
     )
 ]
 
+compiler_directives = {"language_level": 3}
+ext_modules = cythonize(ext_modules, compiler_directives=compiler_directives)
+
 setup(
-    name='cython_bbox',
-    ext_modules=cythonize(ext_modules),
-    version = '0.1.3',
-    description = 'Standalone cython_bbox',
+    name="cython_bbox",
+    ext_modules=ext_modules,
+    version="0.1.3",
+    description="Standalone cython_bbox",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    author = 'Samson Wang',
-    author_email = 'samson.c.wang@gmail.com',
-    url = 'https://github.com/samson-wang/cython_bbox.git', 
-    keywords = ['cython_bbox']
+    author="Samson Wang",
+    author_email="samson.c.wang@gmail.com",
+    url="https://github.com/samson-wang/cython_bbox.git",
+    keywords=["cython_bbox"],
 )
-


### PR DESCRIPTION
- Setup build dependencies in `pyproject.toml` to solve chicken and egg problem
- Specify numpy >= 1.0.0 to ensure we just need `get_include()`